### PR TITLE
SLIDESCLOUDDOC-43 Reading properties of paragraphs

### DIFF
--- a/slides/developer-guide/working-with-text/_index.md
+++ b/slides/developer-guide/working-with-text/_index.md
@@ -5,6 +5,12 @@ url: /working-with-text/
 weight: 90
 ---
 
+- [Read Properties of Paragraphs from a PowerPoint Presentation](/slides/read-properties-of-paragraphs-from-a-powerpoint-presentation/)
+<!-- - [Create a New Paragraph in a PowerPoint Presentation](/slides/create-a-new-paragraph-in-a-powerpoint-presentation/) -->
+<!-- - [Remove a Range of Paragraphs from a PowerPoint Presentation](/slides/remove-a-range-of-paragraphs-from-a-powerpoint-presentation/) -->
+<!-- - [Read Properties of a Paragraph by Index from a PowerPoint Presentation](/slides/read-properties-of-a-paragraph-by-index-from-a-powerpoint-presentation/) -->
+<!-- - [Update Properties of a Paragraph by Index in a PowerPoint Presentation](/slides/update-properties-of-a-paragraph-by-index-in-a-powerpoint-presentation/) -->
+<!-- - [Remove a Paragraph by Index from a PowerPoint Presentation](/slides/remove-a-paragraph-by-index-from-a-powerpoint-presentation/) -->
 - [Read TextItems from a PowerPoint Presentation](/slides/read-textitems-from-a-powerpoint-presentation/)
 - [Replace occurrence of a Text in a PowerPoint Presentation](/slides/replace-occurrence-of-a-text-in-a-powerpoint-presentation/)
 - [Replace Text in a PowerPoint Presentation Not Using the Storage](/slides/replace-text-in-a-powerpoint-presentation-not-using-the-storage/)

--- a/slides/developer-guide/working-with-text/create-a-new-paragraph-in-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/create-a-new-paragraph-in-a-powerpoint-presentation/_index.md
@@ -1,0 +1,149 @@
+---
+title: "Create a New Paragraph in a PowerPoint Presentation"
+type: docs
+url: /create-a-new-paragraph-in-a-powerpoint-presentation/
+weight: 20
+---
+
+## **Introduction**
+This article shows how you can create a new paragraph in PowerPoint presentations using Aspose.Slides for Cloud API. You can use our REST API with any language: .NET, Java, PHP, Ruby, Rails, Python, jQuery, and much more.
+
+## **API Information**
+
+|**API**|**Type**|**Description**|**Resource**|
+| :- | :- | :- | :- |
+|/slides/{name}/slides/{slideIndex}/shapes/{shapeIndex}/paragraphs|POST|Creates a new paragraph in a shape.|[CreateParagraph](https://apireference.aspose.cloud/slides/#/Shapes/CreateParagraph)|
+
+###### **Request Parameters**
+
+|**Name**|**Type**|**Location**|**Required**|**Description**|
+| :- | :- | :- | :- | :- |
+|name|string|path|true|The presentation file name.|
+|slideIndex|integer|path|true|The 1-based index of the presentation slide.|
+|shapeIndex|integer|path|true|The 1-based index of the shape.|
+|dto|object|body|true|The data transfer object of the paragraph.|
+|position|integer|query|false|The position of the new paragraph in the list. Default is at the end of the list.|
+|password|string|header|false|The password to open the presentation.|
+|folder|string|query|false|The folder where the presentation file is located.|
+|storage|string|query|false|The storage where the presentation file is located.|
+
+*In case of Amazon S3 storage folder path starts with Amazon S3 bucket name.*
+
+## **cURL Example**
+Add a new paragraph to the end of a shape (Text Box) at index 2 on the first slide. The paragraph text must be "Best regards, John" and spacing above the paragraph must be 24 pt. The storage is 'Main'. The folder is 'Data'.
+
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+
+{{< tab tabNum="1" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## **SDK Source**
+The Aspose for Cloud SDKs can be downloaded from the following page: [Available SDKs](https://docs.aspose.cloud/slides/available-sdks/).
+
+## **SDK Examples**
+{{< tabs tabTotal="11" tabID="5" tabName1="C#" tabName2="Java" tabName3="PHP" tabName4="Ruby" tabName5="Python" tabName6="Node.js" tabName7="Android" tabName8="C++" tabName9="Perl" tabName10="Swift" tabName11="Go" >}}
+
+{{< tab tabNum="1" >}}
+
+```csharp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="3" >}}
+
+```php
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="4" >}}
+
+```ruby
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="5" >}}
+
+```python
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="6" >}}
+
+```js
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="7" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="8" >}}
+
+```cpp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="9" >}}
+
+```perl
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="10" >}}
+
+```swift
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="11" >}}
+
+```go
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}

--- a/slides/developer-guide/working-with-text/read-properties-of-a-paragraph-by-index-from-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/read-properties-of-a-paragraph-by-index-from-a-powerpoint-presentation/_index.md
@@ -1,0 +1,146 @@
+---
+title: "Read Properties of a Paragraph by Index from a PowerPoint Presentation"
+type: docs
+url: /read-properties-of-a-paragraph-by-index-from-a-powerpoint-presentation/
+weight: 40
+---
+
+## **Introduction**
+This article shows how you can read properties of a paragraph by index from PowerPoint presentations using Aspose.Slides for Cloud API. You can use our REST API with any language: .NET, Java, PHP, Ruby, Rails, Python, jQuery, and much more.
+
+## **API Information**
+
+|**API**|**Type**|**Description**|**Resource**|
+| :- | :- | :- | :- |
+|/slides/{name}/slides/{slideIndex}/shapes/{shapeIndex}/paragraphs/{paragraphIndex}|GET|Reads properties of a paragraph in a shape.|[GetParagraph](https://apireference.aspose.cloud/slides/#/Shapes/GetParagraph)|
+
+###### **Request Parameters**
+
+|**Name**|**Type**|**Location**|**Required**|**Description**|
+| :- | :- | :- | :- | :- |
+|name|string|path|true|The presentation file name.|
+|slideIndex|integer|path|true|The 1-based index of the presentation slide.|
+|shapeIndex|integer|path|true|The 1-based index of the shape.|
+|paragraphIndex|integer|path|true|The 1-based index of the paragraph.|
+|password|string|header|false|The password to open the presentation.|
+|folder|string|query|false|The folder where the presentation file is located.|
+|storage|string|query|false|The storage where the presentation file is located.|
+
+*In case of Amazon S3 storage folder path starts with Amazon S3 bucket name.*
+
+## **cURL Example**
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+
+{{< tab tabNum="1" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## **SDK Source**
+The Aspose for Cloud SDKs can be downloaded from the following page: [Available SDKs](https://docs.aspose.cloud/slides/available-sdks/).
+
+## **SDK Examples**
+{{< tabs tabTotal="11" tabID="5" tabName1="C#" tabName2="Java" tabName3="PHP" tabName4="Ruby" tabName5="Python" tabName6="Node.js" tabName7="Android" tabName8="C++" tabName9="Perl" tabName10="Swift" tabName11="Go" >}}
+
+{{< tab tabNum="1" >}}
+
+```csharp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="3" >}}
+
+```php
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="4" >}}
+
+```ruby
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="5" >}}
+
+```python
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="6" >}}
+
+```js
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="7" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="8" >}}
+
+```cpp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="9" >}}
+
+```perl
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="10" >}}
+
+```swift
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="11" >}}
+
+```go
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}

--- a/slides/developer-guide/working-with-text/read-properties-of-paragraphs-from-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/read-properties-of-paragraphs-from-a-powerpoint-presentation/_index.md
@@ -1,0 +1,398 @@
+---
+title: "Read Properties of Paragraphs from a PowerPoint Presentation"
+type: docs
+url: /read-properties-of-paragraphs-from-a-powerpoint-presentation/
+weight: 10
+---
+
+## **Introduction**
+This article shows how you can read the formatting properties of paragraphs from PowerPoint presentations using Aspose.Slides for Cloud API. You can use our REST API with any language: .NET, Java, PHP, Ruby, Rails, Python, jQuery, and much more.
+
+## **API Information**
+
+|**API**|**Type**|**Description**|**Resource**|
+| :- | :- | :- | :- |
+|/slides/{name}/slides/{slideIndex}/shapes/{shapeIndex}/paragraphs|GET|Reads properties of paragraphs in a shape.|[GetParagraphs](https://apireference.aspose.cloud/slides/#/Shapes/GetParagraphs)|
+
+###### **Request Parameters**
+
+|**Name**|**Type**|**Location**|**Required**|**Description**|
+| :- | :- | :- | :- | :- |
+|name|string|path|true|The presentation file name.|
+|slideIndex|integer|path|true|The 1-based index of the presentation slide.|
+|shapeIndex|integer|path|true|The 1-based index of the shape.|
+|password|string|header|false|The password to open the presentation.|
+|folder|string|query|false|The folder where the presentation file is located.|
+|storage|string|query|false|The storage where the presentation file is located.|
+
+*In case of Amazon S3 storage folder path starts with Amazon S3 bucket name.*
+
+## **cURL Example**
+Read information about paragraphs from a shape at index 3 on a slide at index 1 in example.pptx. The storage is 'Main'. The folder is 'Data'.
+
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+
+{{< tab tabNum="1" >}}
+
+```
+curl -v -X GET "https://api.aspose.cloud/v3.0/slides/example.pptx/slides/1/shapes/3/paragraphs?folder=Data&storage=Main" -H "Accept: application/json" -H %token% --ssl-no-revoke
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```
+{
+  "paragraphLinks": [
+    {
+      "href": "https://api.aspose.cloud/v3.0/slides/example.pptx/slides/1/shapes/3/paragraphs/1?folder=Data",
+      "relation": "self"
+    },
+    {
+      "href": "https://api.aspose.cloud/v3.0/slides/example.pptx/slides/1/shapes/3/paragraphs/2?folder=Data",
+      "relation": "self"
+    }
+  ],
+  "selfUri": {
+    "href": "https://api.aspose.cloud/v3.0/slides/example.pptx/slides/1/shapes/3/paragraphs?folder=Data",
+    "relation": "self"
+  }
+}
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## **SDK Source**
+The Aspose for Cloud SDKs can be downloaded from the following page: [Available SDKs](https://docs.aspose.cloud/slides/available-sdks/).
+
+## **SDK Examples**
+Read the number of paragraphs in a shape at index 3 on a slide at index 1 in example.pptx. The storage is 'Main'. The folder is 'Data'.
+
+{{< tabs tabTotal="11" tabID="5" tabName1="C#" tabName2="Java" tabName3="PHP" tabName4="Ruby" tabName5="Python" tabName6="Node.js" tabName7="Android" tabName8="C++" tabName9="Perl" tabName10="Swift" tabName11="Go" >}}
+
+{{< tab tabNum="1" >}}
+
+```csharp
+// For complete examples and data files, please go to https://github.com/aspose-Slides-cloud/aspose-Slides-cloud-dotnet
+
+using System;
+using System.IO;
+using Aspose.Slides.Cloud.Sdk;
+
+namespace SlidesCloudApp
+{
+    class Test
+    {
+        static void Main()
+        {
+            var slidesApi = new SlidesApi("my_client_id", "my_client_key");
+
+            var fileName = "example.pptx";
+            var folderName = "Data";
+            var storageName = "Main";
+            var filePath = Path.Combine(folderName, fileName);
+            var slideIndex = 1;
+            var shapeIndex = 3;
+            string password = null;
+
+            try
+            {
+                using (var fileStream = File.OpenRead(fileName))
+                {
+                    slidesApi.UploadFile(filePath, fileStream, storageName);
+
+                    var paragraphs = slidesApi.GetParagraphs(fileName, slideIndex, shapeIndex, password, folderName, storageName);
+                    var paragraphCount = paragraphs.ParagraphLinks.Count;
+                    Console.WriteLine(paragraphCount);
+                }
+            }
+            catch (ApiException e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+}
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```java
+// For complete examples and data files, please go to https://github.com/aspose-Slides-cloud/aspose-Slides-cloud-java
+
+import com.aspose.slides.api.SlidesApi;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class Main {
+    public static void main(String[] args) {
+        var slidesApi = new SlidesApi("my_client_id", "my_client_key");
+
+        var fileName = "example.pptx";
+        var folderName = "Data";
+        var storageName = "Main";
+        var filePath = Paths.get(folderName, fileName).toString().replace('\\', '/');
+        var slideIndex = 1;
+        var shapeIndex = 3;
+        String password = null;
+
+        try {
+            var fileData = Files.readAllBytes(new File(fileName).toPath());
+            slidesApi.uploadFile(filePath, fileData, storageName);
+
+            var paragraphs = slidesApi.getParagraphs(fileName, slideIndex, shapeIndex, password, folderName, storageName);
+            var paragraphCount = paragraphs.getParagraphLinks().size();
+            System.out.println(paragraphCount);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="3" >}}
+
+```php
+// For complete examples and data files, please go to https://github.com/aspose-Slides-cloud/aspose-Slides-cloud-php
+
+use Aspose\Slides\Cloud\Sdk\Api\Configuration;
+use Aspose\Slides\Cloud\Sdk\Api\SlidesApi;
+
+$configuration = new Configuration();
+$configuration->setAppSid("my_client_id");
+$configuration->setAppKey("my_client_key");
+
+$slidesApi = new SlidesApi(null, $configuration);
+
+$fileName = "example.pptx";
+$folderName = "Data";
+$storageName = "Main";
+$filePath = join("/", array($folderName, $fileName));
+$slideIndex = 1;
+$shapeIndex = 3;
+$password = null;
+
+try {
+    $fileStream = fopen($fileName, 'r');
+    $slidesApi->uploadFile($filePath, $fileStream, $storageName);
+
+    $paragraphs = $slidesApi->getParagraphs($fileName, $slideIndex, $shapeIndex, $password, $folderName, $storageName);
+    $paragraphCount = count($paragraphs->getParagraphLinks());
+    echo $paragraphCount;
+}
+catch (ApiException $e) {
+    echo $e;
+}
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="4" >}}
+
+```ruby
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="5" >}}
+
+```python
+# For complete examples and data files, please go to https://github.com/aspose-Slides-cloud/aspose-Slides-cloud-python
+
+import asposeslidescloud
+import os
+
+from asposeslidescloud.configuration import Configuration
+from asposeslidescloud.apis.slides_api import SlidesApi
+from asposeslidescloud.rest import ApiException
+
+configuration = Configuration()
+configuration.app_sid = "my_client_id"
+configuration.app_key = "my_client_key"
+
+slidesApi = SlidesApi(configuration)
+
+fileName = "example.pptx"
+folderName = "Data"
+storageName = "Main"
+filePath = os.path.join(folderName, fileName)
+slideIndex = 1
+shapeIndex = 3
+password = None
+
+try:
+    with open(fileName, "rb") as reader:
+        document = reader.read()
+
+    slidesApi.upload_file(filePath, document)
+
+    paragraphs = slidesApi.get_paragraphs(fileName, slideIndex, shapeIndex, password, folderName, storageName)
+    paragraphCount = len(paragraphs.paragraph_links)
+    print(paragraphCount)
+except ApiException as e:
+	print(e)
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="6" >}}
+
+```js
+// https://github.com/aspose-Slides-cloud/aspose-Slides-cloud-nodejs
+
+const api = require("asposeslidescloud")
+const fs = require("fs")
+const path = require("path")
+
+const slidesApi = new api.SlidesApi("my_client_id", "my_client_key")
+
+const fileName = "example.pptx"
+const folderName = "Data"
+const storageName = "Main"
+const filePath = path.join(folderName, fileName)
+const slideIndex = 1
+const shapeIndex = 3
+const password = null
+
+const readStream = fs.createReadStream(fileName)
+
+slidesApi.uploadFile(filePath, readStream, storageName).then(() => {
+    slidesApi.getParagraphs(fileName, slideIndex, shapeIndex, password, folderName, storageName).then((paragraphs) => {
+        const paragraphCount = paragraphs.body.paragraphLinks.length
+        console.log(paragraphCount)
+    })
+    .catch(function (error) {
+        console.error(error)
+    })
+})
+.catch(function (error) {
+    console.error(error)
+})
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="7" >}}
+
+```java
+// For complete examples and data files, please go to https://github.com/aspose-Slides-cloud/aspose-Slides-cloud-android
+
+import com.aspose.slides.api.SlidesApi;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class Main {
+    public static void main(String[] args) {
+        var slidesApi = new SlidesApi("my_client_id", "my_client_key");
+
+        var fileName = "example.pptx";
+        var folderName = "Data";
+        var storageName = "Main";
+        var filePath = Paths.get(folderName, fileName).toString().replace('\\', '/');
+        var slideIndex = 1;
+        var shapeIndex = 3;
+        String password = null;
+
+        try {
+            var fileData = Files.readAllBytes(new File(fileName).toPath());
+            slidesApi.uploadFile(filePath, fileData, storageName);
+
+            var paragraphs = slidesApi.getParagraphs(fileName, slideIndex, shapeIndex, password, folderName, storageName);
+            var paragraphCount = paragraphs.getParagraphLinks().size();
+            System.out.println(paragraphCount);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="8" >}}
+
+```cpp
+// For complete examples and data files, please go to https://github.com/aspose-Slides-cloud/aspose-Slides-cloud-cpp
+
+#include <asposeslidescloud/api/SlidesApi.h>
+
+using namespace utility::conversions;
+using namespace asposeslidescloud::api;
+
+int main()
+{
+    auto configuration = std::make_shared<ApiConfiguration>();
+    configuration->setAppSid(to_string_t("my_client_id"));
+    configuration->setAppKey(to_string_t("my_client_key"));
+    
+    auto slidesApi = std::make_shared<SlidesApi>(configuration);
+
+	auto fileName = to_string_t("example.pptx");
+	auto folderName = to_string_t("Data");
+	auto storageName = to_string_t("Main");
+	auto filePath = folderName + to_string_t("/") + fileName;
+	auto slideIndex = 1;
+	auto shapeIndex = 3;
+	auto password = utility::string_t();
+	
+	try
+	{
+		auto fileStream = std::make_shared<std::ifstream>(fileName, std::ios::binary);
+		
+		auto uploadContent = std::make_shared<HttpContent>();
+		uploadContent->setData(fileStream);
+		
+		slidesApi->uploadFile(filePath, uploadContent, storageName).wait();
+		
+		auto paragraphs = slidesApi->getParagraphs(
+			fileName, slideIndex, shapeIndex, password, folderName, storageName).get();
+
+		auto paragraphCount = paragraphs->getParagraphLinks().size();
+		std::cout << paragraphCount;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << e.what();
+	}
+	
+	return 0;
+}
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="9" >}}
+
+```perl
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="10" >}}
+
+```swift
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="11" >}}
+
+```go
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}

--- a/slides/developer-guide/working-with-text/read-textitems-from-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/read-textitems-from-a-powerpoint-presentation/_index.md
@@ -2,7 +2,7 @@
 title: "Read TextItems from a PowerPoint Presentation"
 type: docs
 url: /read-textitems-from-a-powerpoint-presentation/
-weight: 10
+weight: 70
 ---
 
 ## **Introduction**

--- a/slides/developer-guide/working-with-text/remove-a-paragraph-by-index-from-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/remove-a-paragraph-by-index-from-a-powerpoint-presentation/_index.md
@@ -1,0 +1,146 @@
+---
+title: "Remove a Paragraph by Index from a PowerPoint Presentation"
+type: docs
+url: /remove-a-paragraph-by-index-from-a-powerpoint-presentation/
+weight: 60
+---
+
+## **Introduction**
+This article shows how you can remove a paragraph by index in PowerPoint presentations using Aspose.Slides for Cloud API. You can use our REST API with any language: .NET, Java, PHP, Ruby, Rails, Python, jQuery, and much more.
+
+## **API Information**
+
+|**API**|**Type**|**Description**|**Resource**|
+| :- | :- | :- | :- |
+|/slides/{name}/slides/{slideIndex}/shapes/{shapeIndex}/paragraphs/{paragraphIndex}|DELETE|Removes a paragraph in a shape.|[DeleteParagraph](https://apireference.aspose.cloud/slides/#/Shapes/DeleteParagraph)|
+
+###### **Request Parameters**
+
+|**Name**|**Type**|**Location**|**Required**|**Description**|
+| :- | :- | :- | :- | :- |
+|name|string|path|true|The presentation file name.|
+|slideIndex|integer|path|true|The 1-based index of the presentation slide.|
+|shapeIndex|integer|path|true|The 1-based index of the shape.|
+|paragraphIndex|integer|path|true|The 1-based index of the paragraph.|
+|password|string|header|false|The password to open the presentation.|
+|folder|string|query|false|The folder where the presentation file is located.|
+|storage|string|query|false|The storage where the presentation file is located.|
+
+*In case of Amazon S3 storage folder path starts with Amazon S3 bucket name.*
+
+## **cURL Example**
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+
+{{< tab tabNum="1" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## **SDK Source**
+The Aspose for Cloud SDKs can be downloaded from the following page: [Available SDKs](https://docs.aspose.cloud/slides/available-sdks/).
+
+## **SDK Examples**
+{{< tabs tabTotal="11" tabID="5" tabName1="C#" tabName2="Java" tabName3="PHP" tabName4="Ruby" tabName5="Python" tabName6="Node.js" tabName7="Android" tabName8="C++" tabName9="Perl" tabName10="Swift" tabName11="Go" >}}
+
+{{< tab tabNum="1" >}}
+
+```csharp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="3" >}}
+
+```php
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="4" >}}
+
+```ruby
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="5" >}}
+
+```python
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="6" >}}
+
+```js
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="7" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="8" >}}
+
+```cpp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="9" >}}
+
+```perl
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="10" >}}
+
+```swift
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="11" >}}
+
+```go
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}

--- a/slides/developer-guide/working-with-text/remove-a-range-of-paragraphs-from-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/remove-a-range-of-paragraphs-from-a-powerpoint-presentation/_index.md
@@ -1,0 +1,146 @@
+---
+title: "Remove a Range of Paragraphs from a PowerPoint Presentation"
+type: docs
+url: /remove-a-range-of-paragraphs-from-a-powerpoint-presentation/
+weight: 30
+---
+
+## **Introduction**
+This article shows how you can remove a range of paragraphs in PowerPoint presentations using Aspose.Slides for Cloud API. You can use our REST API with any language: .NET, Java, PHP, Ruby, Rails, Python, jQuery, and much more.
+
+## **API Information**
+
+|**API**|**Type**|**Description**|**Resource**|
+| :- | :- | :- | :- |
+|/slides/{name}/slides/{slideIndex}/shapes/{shapeIndex}/paragraphs|DELETE|Removes a range of paragraphs in a shape.|[DeleteParagraphs](https://apireference.aspose.cloud/slides/#/Shapes/DeleteParagraphs)|
+
+###### **Request Parameters**
+
+|**Name**|**Type**|**Location**|**Required**|**Description**|
+| :- | :- | :- | :- | :- |
+|name|string|path|true|The presentation file name.|
+|slideIndex|integer|path|true|The 1-based index of the presentation slide.|
+|shapeIndex|integer|path|true|The 1-based index of the shape.|
+|paragraphs|string|query|false|The indices of paragraphs to be deleted. Delete all by default.|
+|password|string|header|false|The password to open the presentation.|
+|folder|string|query|false|The folder where the presentation file is located.|
+|storage|string|query|false|The storage where the presentation file is located.|
+
+*In case of Amazon S3 storage folder path starts with Amazon S3 bucket name.*
+
+## **cURL Example**
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+
+{{< tab tabNum="1" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## **SDK Source**
+The Aspose for Cloud SDKs can be downloaded from the following page: [Available SDKs](https://docs.aspose.cloud/slides/available-sdks/).
+
+## **SDK Examples**
+{{< tabs tabTotal="11" tabID="5" tabName1="C#" tabName2="Java" tabName3="PHP" tabName4="Ruby" tabName5="Python" tabName6="Node.js" tabName7="Android" tabName8="C++" tabName9="Perl" tabName10="Swift" tabName11="Go" >}}
+
+{{< tab tabNum="1" >}}
+
+```csharp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="3" >}}
+
+```php
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="4" >}}
+
+```ruby
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="5" >}}
+
+```python
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="6" >}}
+
+```js
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="7" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="8" >}}
+
+```cpp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="9" >}}
+
+```perl
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="10" >}}
+
+```swift
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="11" >}}
+
+```go
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}

--- a/slides/developer-guide/working-with-text/replace-occurrence-of-a-text-in-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/replace-occurrence-of-a-text-in-a-powerpoint-presentation/_index.md
@@ -2,7 +2,7 @@
 title: "Replace occurrence of a Text in a PowerPoint Presentation"
 type: docs
 url: /replace-occurrence-of-a-text-in-a-powerpoint-presentation/
-weight: 20
+weight: 80
 ---
 
 ## **Introduction**

--- a/slides/developer-guide/working-with-text/replace-text-in-a-powerpoint-presentation-not-using-the-storage/_index.md
+++ b/slides/developer-guide/working-with-text/replace-text-in-a-powerpoint-presentation-not-using-the-storage/_index.md
@@ -2,7 +2,7 @@
 title: "Replace Text in a PowerPoint Presentation Not Using the Storage"
 type: docs
 url: /replace-text-in-a-powerpoint-presentation-not-using-the-storage/
-weight: 20
+weight: 90
 ---
 
 ## **Introduction**

--- a/slides/developer-guide/working-with-text/update-properties-of-a-paragraph-by-index-in-a-powerpoint-presentation/_index.md
+++ b/slides/developer-guide/working-with-text/update-properties-of-a-paragraph-by-index-in-a-powerpoint-presentation/_index.md
@@ -1,0 +1,147 @@
+---
+title: "Update Properties of a Paragraph by Index in a PowerPoint Presentation"
+type: docs
+url: /update-properties-of-a-paragraph-by-index-in-a-powerpoint-presentation/
+weight: 50
+---
+
+## **Introduction**
+This article shows how you can update properties of a paragraph by index in PowerPoint presentations using Aspose.Slides for Cloud API. You can use our REST API with any language: .NET, Java, PHP, Ruby, Rails, Python, jQuery, and much more.
+
+## **API Information**
+
+|**API**|**Type**|**Description**|**Resource**|
+| :- | :- | :- | :- |
+|/slides/{name}/slides/{slideIndex}/shapes/{shapeIndex}/paragraphs/{paragraphIndex}|PUT|Updates properties of a paragraph in a shape.|[UpdateParagraph](https://apireference.aspose.cloud/slides/#/Shapes/UpdateParagraph)|
+
+###### **Request Parameters**
+
+|**Name**|**Type**|**Location**|**Required**|**Description**|
+| :- | :- | :- | :- | :- |
+|name|string|path|true|The presentation file name.|
+|slideIndex|integer|path|true|The 1-based index of the presentation slide.|
+|shapeIndex|integer|path|true|The 1-based index of the shape.|
+|paragraphIndex|integer|path|true|The 1-based index of the paragraph.|
+|dto|object|body|true|The data transfer object of the paragraph.|
+|password|string|header|false|The password to open the presentation.|
+|folder|string|query|false|The folder where the presentation file is located.|
+|storage|string|query|false|The storage where the presentation file is located.|
+
+*In case of Amazon S3 storage folder path starts with Amazon S3 bucket name.*
+
+## **cURL Example**
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+
+{{< tab tabNum="1" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## **SDK Source**
+The Aspose for Cloud SDKs can be downloaded from the following page: [Available SDKs](https://docs.aspose.cloud/slides/available-sdks/).
+
+## **SDK Examples**
+{{< tabs tabTotal="11" tabID="5" tabName1="C#" tabName2="Java" tabName3="PHP" tabName4="Ruby" tabName5="Python" tabName6="Node.js" tabName7="Android" tabName8="C++" tabName9="Perl" tabName10="Swift" tabName11="Go" >}}
+
+{{< tab tabNum="1" >}}
+
+```csharp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="3" >}}
+
+```php
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="4" >}}
+
+```ruby
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="5" >}}
+
+```python
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="6" >}}
+
+```js
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="7" >}}
+
+```java
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="8" >}}
+
+```cpp
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="9" >}}
+
+```perl
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="10" >}}
+
+```swift
+
+```
+
+{{< /tab >}}
+
+{{< tab tabNum="11" >}}
+
+```go
+
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}


### PR DESCRIPTION
SLIDESCLOUDDOC-43 Started writing an article about paragraphs

SLIDESCLOUDDOC-43 Introduction, API Information, Request Parameters

SLIDESCLOUDDOC-43 Request Parameters section is updated

SLIDESCLOUDDOC-43 Article structure is added

SLIDESCLOUDDOC-43 The article is separated

SLIDESCLOUDDOC-43 Description of parameters is improved

SLIDESCLOUDDOC-43 Added a skeleton for articles

SLIDESCLOUDDOC-43 cURL example for "Read Properties of Paragraphs"

SLIDESCLOUDDOC-43 C# code example for "Read Properties of Paragraphs"

SLIDESCLOUDDOC-43 C# code example is updated and PHP code example is added for "Read Properties of Paragraphs" article

SLIDESCLOUDDOC-43 Python code example for "Read Properties of Paragraphs"

SLIDESCLOUDDOC-43 C++ code example for "Read Properties of Paragraphs" article

SLIDESCLOUDDOC-43 Code examples are updated, Java code example is added

SLIDESCLOUDDOC-43 Android code example for "Read Properties of Paragraphs" article

SLIDESCLOUDDOC-43 Node.js code example for "Read Properties of Paragraphs" article

SLIDESCLOUDDOC-43 C# code example is improved

SLIDESCLOUDDOC-43 Java code example is improved

SLIDESCLOUDDOC-43 PHP code example is improved

SLIDESCLOUDDOC-43 Python code example is improved

SLIDESCLOUDDOC-43 Android code example is improved

SLIDESCLOUDDOC-43 C++ code example is improved

SLIDESCLOUDDOC-43 Empty tabs for Swift and Go code examples

SLIDESCLOUDDOC-43 Structure of articles are changed